### PR TITLE
Enable S3 encryption for all S3 buckets

### DIFF
--- a/amplify/backend/custom/qickworkloadstorage/qickworkloadstorage-cloudformation-template.json
+++ b/amplify/backend/custom/qickworkloadstorage/qickworkloadstorage-cloudformation-template.json
@@ -52,6 +52,15 @@
               "MaxAge": 3600
             }
           ]
+        },
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
         }
       }
     },
@@ -83,6 +92,15 @@
                 "*"
               ],
               "MaxAge": 3600
+            }
+          ]
+        },
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
             }
           ]
         }
@@ -127,5 +145,5 @@
       }
     }
   },
-  "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"Amplify\",\"createdWith\":\"9.2.1\",\"stackType\":\"custom-customCloudformation\",\"metadata\":{}}"
+  "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"Amplify\",\"createdWith\":\"14.2.3\",\"stackType\":\"custom-customCloudformation\",\"metadata\":{\"whyContinueWithGen1\":\"\"}}"
 }


### PR DESCRIPTION
This change makes sure any existing buckets would have encryption enabled by default.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
